### PR TITLE
Update decoder.go : loads charset data 

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -10,6 +10,7 @@ import (
 	"mime/quotedprintable"
 
 	"github.com/paulrosania/go-charset/charset"
+	_ "github.com/paulrosania/go-charset/charset/data"
 )
 
 func UTF8(cs string, data []byte) ([]byte, error) {


### PR DESCRIPTION
To avoid  `cannot open "charsets.json"` , because the address is hardcoded in https://github.com/paulrosania/go-charset/blob/master/charset/file.go